### PR TITLE
Refactoring of handling of cluster metadata in KafkaSession

### DIFF
--- a/lib/kafka.dart
+++ b/lib/kafka.dart
@@ -13,7 +13,7 @@ import 'common.dart';
 import 'protocol.dart';
 
 export 'common.dart';
-export 'protocol.dart' show MetadataResponse;
+export 'protocol.dart' show TopicMetadata;
 
 part 'src/common.dart';
 part 'src/consumer.dart';

--- a/lib/src/common/messages.dart
+++ b/lib/src/common/messages.dart
@@ -17,16 +17,12 @@ class MessageAttributes {
 
   static KafkaCompression getCompression(int byte) {
     var c = byte & 3;
-    switch (c) {
-      case 0:
-        return KafkaCompression.none;
-      case 1:
-        return KafkaCompression.gzip;
-      case 2:
-        return KafkaCompression.snappy;
-      default:
-        throw new ArgumentError('Unsupported compression codec: ${c}.');
-    }
+    var map = {
+      0: KafkaCompression.none,
+      1: KafkaCompression.gzip,
+      2: KafkaCompression.snappy,
+    };
+    return map[c];
   }
 
   /// Converts this attributes into byte.

--- a/lib/src/consumer.dart
+++ b/lib/src/consumer.dart
@@ -87,7 +87,7 @@ class Consumer {
 
   Future<List<_ConsumerWorker>> _buildWorkers(
       _MessageStreamController controller) async {
-    var meta = await session.getMetadata();
+    var meta = await session.getMetadata(topicPartitions.keys.toSet());
     var topicsByBroker = new Map<Broker, Map<String, Set<int>>>();
 
     topicPartitions.forEach((topic, partitions) {

--- a/lib/src/fetcher.dart
+++ b/lib/src/fetcher.dart
@@ -48,7 +48,8 @@ class Fetcher {
 
   Future<List<_FetcherWorker>> _buildWorkers(
       _MessageStreamController controller) async {
-    var meta = await session.getMetadata();
+    var topicNames = topicOffsets.map((_) => _.topicName).toSet();
+    var meta = await session.getMetadata(topicNames);
     var offsetsByBroker = new Map<Broker, List<TopicOffset>>();
 
     topicOffsets.forEach((offset) {

--- a/lib/src/offset_master.dart
+++ b/lib/src/offset_master.dart
@@ -27,7 +27,8 @@ class OffsetMaster {
   Future<List<TopicOffset>> _fetch(
       Map<String, Set<int>> topicPartitions, int time,
       {refreshMetadata: false}) async {
-    var meta = await session.getMetadata(invalidateCache: refreshMetadata);
+    var meta = await session.getMetadata(topicPartitions.keys.toSet(),
+        invalidateCache: refreshMetadata);
     var requests = new Map<Broker, OffsetRequest>();
     for (var topic in topicPartitions.keys) {
       var partitions = topicPartitions[topic];

--- a/lib/src/producer.dart
+++ b/lib/src/producer.dart
@@ -35,7 +35,8 @@ class Producer {
 
   /// Sends messages to Kafka.
   Future<ProduceResult> produce(List<ProduceEnvelope> messages) async {
-    var meta = await session.getMetadata();
+    var topicNames = messages.map((_) => _.topicName).toSet();
+    var meta = await session.getMetadata(topicNames);
     Map<Broker, List<ProduceEnvelope>> envelopesByBroker = new Map();
     for (var envelope in messages) {
       var topic = meta.getTopicMetadata(envelope.topicName);

--- a/lib/src/protocol/metadata_api.dart
+++ b/lib/src/protocol/metadata_api.dart
@@ -64,17 +64,6 @@ class MetadataResponse {
         KafkaType.object, (reader) => new TopicMetadata._readFrom(reader));
     return new MetadataResponse._(brokers, topicMetadata);
   }
-
-  /// Returns [Broker] by specified [nodeId].
-  Broker getBroker(int nodeId) {
-    return brokers.firstWhere((b) => b.id == nodeId);
-  }
-
-  TopicMetadata getTopicMetadata(String topicName) {
-    return topics.firstWhere((topic) => topic.topicName == topicName,
-        orElse: () =>
-            throw new StateError('No topic ${topicName} found in metadata.'));
-  }
 }
 
 /// Represents Kafka TopicMetadata data structure returned in MetadataResponse.

--- a/lib/src/protocol/metadata_api.dart
+++ b/lib/src/protocol/metadata_api.dart
@@ -10,7 +10,7 @@ class MetadataRequest extends KafkaRequest {
 
   /// List of topic names to fetch metadata for. If set to null or empty
   /// this request will fetch metadata for all topics.
-  final List<String> topicNames;
+  final Set<String> topicNames;
 
   /// Creats new instance of Kafka MetadataRequest.
   ///
@@ -22,7 +22,7 @@ class MetadataRequest extends KafkaRequest {
   List<int> toBytes() {
     var builder = new KafkaBytesBuilder.withRequestHeader(
         apiKey, apiVersion, correlationId);
-    List list = (this.topicNames is List) ? this.topicNames : [];
+    Set list = (this.topicNames is Set) ? this.topicNames : new Set();
     builder.addArray(list, KafkaType.string);
 
     var body = builder.takeBytes();

--- a/test/common/messages_test.dart
+++ b/test/common/messages_test.dart
@@ -16,4 +16,18 @@ void main() {
       }, throwsStateError);
     });
   });
+
+  group('MessageAttributes:', () {
+    test('get compression from int', () {
+      expect(KafkaCompression.none, MessageAttributes.getCompression(0));
+      expect(KafkaCompression.gzip, MessageAttributes.getCompression(1));
+      expect(KafkaCompression.snappy, MessageAttributes.getCompression(2));
+    });
+
+    test('convert to int', () {
+      expect(new MessageAttributes(KafkaCompression.none).toInt(), equals(0));
+      expect(new MessageAttributes(KafkaCompression.gzip).toInt(), equals(1));
+      expect(new MessageAttributes(KafkaCompression.snappy).toInt(), equals(2));
+    });
+  });
 }

--- a/test/consumer_group_test.dart
+++ b/test/consumer_group_test.dart
@@ -16,7 +16,7 @@ void main() {
     setUp(() async {
       var host = await getDefaultHost();
       var session = new KafkaSession([new ContactPoint(host, 9092)]);
-      var brokersMetadata = await session.getMetadata();
+      var brokersMetadata = await session.getMetadata([_topicName].toSet());
 
       var metadata = await session.getConsumerMetadata('testGroup');
       _coordinator = metadata.coordinator;

--- a/test/protocol/fetch_test.dart
+++ b/test/protocol/fetch_test.dart
@@ -17,7 +17,7 @@ void main() {
     setUp(() async {
       var ip = await getDefaultHost();
       _session = new KafkaSession([new ContactPoint(ip, 9092)]);
-      var metadata = await _session.getMetadata();
+      var metadata = await _session.getMetadata([_topicName].toSet());
       var leaderId =
           metadata.getTopicMetadata(_topicName).getPartition(0).leader;
       _host = metadata.getBroker(leaderId);

--- a/test/protocol/offset_commit_test.dart
+++ b/test/protocol/offset_commit_test.dart
@@ -17,7 +17,7 @@ void main() {
     setUp(() async {
       var ip = await getDefaultHost();
       _session = new KafkaSession([new ContactPoint(ip, 9092)]);
-      var meta = await _session.getMetadata();
+      var meta = await _session.getMetadata([_topicName].toSet());
       var leaderId = meta.getTopicMetadata(_topicName).getPartition(0).leader;
       _host = meta.getBroker(leaderId);
 

--- a/test/protocol/offset_test.dart
+++ b/test/protocol/offset_test.dart
@@ -16,7 +16,7 @@ void main() {
     setUp(() async {
       var ip = await getDefaultHost();
       _session = new KafkaSession([new ContactPoint(ip, 9092)]);
-      var metadata = await _session.getMetadata();
+      var metadata = await _session.getMetadata([_topicName].toSet());
       var leaderId =
           metadata.getTopicMetadata(_topicName).getPartition(0).leader;
       _broker = metadata.getBroker(leaderId);

--- a/test/protocol/produce_test.dart
+++ b/test/protocol/produce_test.dart
@@ -14,7 +14,7 @@ void main() {
     setUp(() async {
       var ip = await getDefaultHost();
       _session = new KafkaSession([new ContactPoint(ip, 9092)]);
-      var metadata = await _session.getMetadata();
+      var metadata = await _session.getMetadata([_topicName].toSet());
       var leaderId =
           metadata.getTopicMetadata(_topicName).getPartition(0).leader;
       _broker = metadata.getBroker(leaderId);

--- a/test/session_test.dart
+++ b/test/session_test.dart
@@ -7,6 +7,7 @@ import 'setup.dart';
 void main() {
   group('Session:', () {
     KafkaSession _session;
+    String _topicName = 'dartKafkaTest';
 
     setUp(() async {
       var host = await getDefaultHost();
@@ -17,26 +18,18 @@ void main() {
       await _session.close();
     });
 
+    test('it can list existing topics', () async {
+      var topics = await _session.listTopics();
+      expect(topics, new isInstanceOf<Set>());
+      expect(topics, isNotEmpty);
+      expect(topics, contains(_topicName));
+      print(topics);
+    });
+
     test('it can fetch topic metadata', () async {
-      var response = await _session.getMetadata();
-      expect(response, new isInstanceOf<MetadataResponse>());
+      var response = await _session.getMetadata([_topicName].toSet());
+      expect(response, new isInstanceOf<ClusterMetadata>());
       expect(response.brokers, isNotEmpty);
-    });
-
-    test('it caches metadata', () async {
-      var response = await _session.getMetadata();
-      expect(response, new isInstanceOf<MetadataResponse>());
-
-      var response2 = await _session.getMetadata();
-      expect(response2, same(response));
-    });
-
-    test('it invalidates cached metadata', () async {
-      var response = await _session.getMetadata();
-      expect(response, new isInstanceOf<MetadataResponse>());
-
-      var response2 = await _session.getMetadata(invalidateCache: true);
-      expect(response2, isNot(same(response)));
     });
 
     test('it can fetch consumer metadata', () async {

--- a/test/session_test.dart
+++ b/test/session_test.dart
@@ -23,13 +23,35 @@ void main() {
       expect(topics, new isInstanceOf<Set>());
       expect(topics, isNotEmpty);
       expect(topics, contains(_topicName));
-      print(topics);
     });
 
     test('it can fetch topic metadata', () async {
       var response = await _session.getMetadata([_topicName].toSet());
       expect(response, new isInstanceOf<ClusterMetadata>());
       expect(response.brokers, isNotEmpty);
+      var topic = response.getTopicMetadata(_topicName);
+      expect(topic, new isInstanceOf<TopicMetadata>());
+      response = await _session.getMetadata([_topicName].toSet());
+      var newTopic = response.getTopicMetadata(_topicName);
+      expect(newTopic, same(topic));
+    });
+
+    test('it invalidates topic metadata', () async {
+      var response = await _session.getMetadata([_topicName].toSet());
+      var topic = response.getTopicMetadata(_topicName);
+      response = await _session.getMetadata([_topicName].toSet(),
+          invalidateCache: true);
+      var newTopic = response.getTopicMetadata(_topicName);
+      expect(newTopic, isNot(same(topic)));
+    });
+
+    test('it fetches topic metadata for auto-created topics', () async {
+      var date = new DateTime.now().millisecondsSinceEpoch;
+      var topicName = 'testTopic-${date}';
+      var response = await _session.getMetadata([topicName].toSet());
+      var topic = response.getTopicMetadata(topicName);
+      expect(topic.errorCode, equals(KafkaServerErrorCode.NoError));
+      expect(topic.partitions, isNotEmpty);
     });
 
     test('it can fetch consumer metadata', () async {


### PR DESCRIPTION
- Make `topicNames` required in `getMetadata`
- Update Consumer, Producer and others to explicitly request metadata for topics they need
- Requests for "all" existing topics are not cached
- Introduced new `listTopics` method.
